### PR TITLE
More work on OnOff, LevelControl and ScenesCluster

### DIFF
--- a/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.h
@@ -75,23 +75,23 @@ public:
     };
     Q_ENUM(MoveMode)
 
-    enum FadeMode {
-        FadeModeUp = 0x00,
-        FadeModeDown = 0x01
+    enum StepMode {
+        StepModeUp = 0x00,
+        StepModeDown = 0x01
     };
-    Q_ENUM(FadeMode)
+    Q_ENUM(StepMode)
 
     explicit ZigbeeClusterLevelControl(ZigbeeNetwork *network, ZigbeeNode *node, ZigbeeNodeEndpoint *endpoint, Direction direction, QObject *parent = nullptr);
 
     ZigbeeClusterReply *commandMoveToLevel(quint8 level, quint16 transitionTime = 0xffff);
     ZigbeeClusterReply *commandMove(MoveMode moveMode, quint8 rate = 0xff);
-    ZigbeeClusterReply *commandStep(FadeMode fadeMode, quint8 stepSize = 0x01, quint16 transitionTime = 0xffff);
+    ZigbeeClusterReply *commandStep(StepMode stepMode, quint8 stepSize = 0x01, quint16 transitionTime = 0xffff);
     ZigbeeClusterReply *commandStop();
 
     // With on/off
     ZigbeeClusterReply *commandMoveToLevelWithOnOff(quint8 level, quint16 transitionTime = 0xffff);
     ZigbeeClusterReply *commandMoveWithOnOff(MoveMode moveMode, quint8 rate = 0xff);
-    ZigbeeClusterReply *commandStepWithOnOff(FadeMode fadeMode, quint8 stepSize = 0x01, quint16 transitionTime = 0xffff);
+    ZigbeeClusterReply *commandStepWithOnOff(StepMode stepMode, quint8 stepSize = 0x01, quint16 transitionTime = 0xffff);
     ZigbeeClusterReply *commandStopWithOnOff();
 
     quint8 currentLevel() const;
@@ -107,8 +107,10 @@ protected:
 signals:
     void currentLevelChanged(quint8 level);
     void commandSent(ZigbeeClusterLevelControl::Command command, const QByteArray &parameter = QByteArray());
-    void commandMoveSent(MoveMode moveMode, quint8 rate = 0xff);
-    void commandStepSent(FadeMode fadeMode, quint8 stepSize, quint16 transitionTime);
+    void commandMoveToLevelSent(bool withOnOff, quint8 level, quint16 transitionTime);
+    void commandMoveSent(bool withOnOff, MoveMode moveMode, quint8 rate = 0xff);
+    void commandStepSent(bool withOnOff, StepMode stepMode, quint8 stepSize, quint16 transitionTime);
+    void commandStopSent();
 
 };
 

--- a/libnymea-zigbee/zcl/general/zigbeeclusteronoff.cpp
+++ b/libnymea-zigbee/zcl/general/zigbeeclusteronoff.cpp
@@ -114,23 +114,15 @@ void ZigbeeClusterOnOff::processDataIndication(ZigbeeClusterLibrary::Frame frame
         if (frame.header.frameControl.direction == ZigbeeClusterLibrary::DirectionClientToServer) {
             // Read the payload which is
             Command command = static_cast<Command>(frame.header.command);
-            qCDebug(dcZigbeeCluster()) << "Received" << command << "from" << m_node << m_endpoint << this;
+            emit commandSent(command, frame.payload);
             switch (command) {
-            case CommandOn:
-                emit commandSent(CommandOn);
-                break;
-            case CommandOff:
-                emit commandSent(CommandOff);
-                break;
-            case CommandToggle:
-                emit commandSent(CommandToggle);
-                break;
             case CommandOffWithEffect: {
                 QByteArray payload = frame.payload;
                 QDataStream payloadStream(&payload, QIODevice::ReadOnly);
                 payloadStream.setByteOrder(QDataStream::LittleEndian);
                 quint8 effectValue = 0; quint16 effectVariant;
                 payloadStream >> effectValue >> effectVariant;
+                qCDebug(dcZigbeeCluster()) << "Command received from" << m_node << m_endpoint << this << command << "effect:" << effectValue << "effectVariant:" << effectVariant;
                 emit commandOffWithEffectSent(static_cast<Effect>(effectValue), effectVariant);
                 break;
             }
@@ -140,11 +132,12 @@ void ZigbeeClusterOnOff::processDataIndication(ZigbeeClusterLibrary::Frame frame
                 payloadStream.setByteOrder(QDataStream::LittleEndian);
                 quint8 acceptOnlyWhenOnInt = 0; quint16 onTime; quint16 offTime;
                 payloadStream >> acceptOnlyWhenOnInt >> onTime >> offTime;
+                qCDebug(dcZigbeeCluster()) << "Command received from" << m_node << m_endpoint << this << command << "accentOnlyWhenOnInt:" << acceptOnlyWhenOnInt << "onTime:" << onTime << "offTime:" << offTime;
                 emit commandOnWithTimedOffSent(static_cast<bool>(acceptOnlyWhenOnInt), onTime, offTime);
                 break;
             }
             default:
-                qCWarning(dcZigbeeCluster()) << "Unhandled command sent from" << m_node << m_endpoint << this << command << ZigbeeUtils::convertByteArrayToHexString(frame.payload);
+                qCDebug(dcZigbeeCluster()) << "Command received from" << m_node << m_endpoint << this << command << ZigbeeUtils::convertByteArrayToHexString(frame.payload);
                 break;
             }
         }

--- a/libnymea-zigbee/zcl/general/zigbeeclusteronoff.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusteronoff.h
@@ -94,7 +94,7 @@ signals:
     void powerChanged(bool power);
 
     // Client cluster signals
-    void commandSent(Command command);
+    void commandSent(Command command, const QByteArray &parameters = QByteArray());
     // On and off time is in 1/10 seconds
     void commandOnWithTimedOffSent(bool acceptOnlyWhenOn, quint16 onTime, quint16 offTime);
 

--- a/libnymea-zigbee/zcl/general/zigbeeclusterscenes.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterscenes.h
@@ -63,7 +63,7 @@ public:
     explicit ZigbeeClusterScenes(ZigbeeNetwork *network, ZigbeeNode *node, ZigbeeNodeEndpoint *endpoint, Direction direction, QObject *parent = nullptr);
 
 signals:
-    void commandSent(quint8 command, const QByteArray &payload);
+    void commandSent(Command command, quint16 groupId, quint8 sceneId);
 
 private:
     void setAttribute(const ZigbeeClusterAttribute &attribute) override;


### PR DESCRIPTION
This alignes the OnOff cluster with the LevelControl cluster in terms
of signal behavior: Previously, the OnOff cluster would fire a generic
commandSent() signal for some commands and specific signals for others.
Effectively forcing the user to connect multiple signals even if only
the command would be of interest.

The LevelControl cluster instead always fired a generic commandSent()
signal and *additionally* more specific signals for parsed parameters.

This changes the OnOff cluster to be in line with the LevelCluster
as and making the API a bit simpler to use when parameters are not of
interest.

Also it completes the specific parsing for all 3 clusters.