### PR TITLE
Exclude docs and firmware binaries from dpkg source package

### DIFF
--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,2 @@
+tar-ignore = docs
+tar-ignore = firmware


### PR DESCRIPTION
30MB -> 1.5MB and much faster builds