### PR TITLE
Remove 1 from lib name

### DIFF
--- a/debian/libnymea-zigbee-dev.install.in
+++ b/debian/libnymea-zigbee-dev.install.in
@@ -1,3 +1,3 @@
-usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee1.so
+usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee.so
 usr/lib/@DEB_HOST_MULTIARCH@/pkgconfig/nymea-zigbee.pc
 usr/include/nymea-zigbee/* usr/include/nymea-zigbee/

--- a/debian/libnymea-zigbee1.install.in
+++ b/debian/libnymea-zigbee1.install.in
@@ -1,3 +1,3 @@
-usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee1.so.1
-usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee1.so.1.0
-usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee1.so.1.0.0
+usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee.so.1
+usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee.so.1.0
+usr/lib/@DEB_HOST_MULTIARCH@/libnymea-zigbee.so.1.0.0

--- a/libnymea-zigbee/libnymea-zigbee.pro
+++ b/libnymea-zigbee/libnymea-zigbee.pro
@@ -1,6 +1,6 @@
 include(../config.pri)
 
-TARGET = nymea-zigbee1
+TARGET = nymea-zigbee
 TEMPLATE = lib
 
 CONFIG += link_pkgconfig


### PR DESCRIPTION
This is not needed (libraries already have version numers in their names) and quite uncommon.