### PR TITLE
Timeout ZCL replies

### DIFF
--- a/libnymea-zigbee/zcl/zigbeeclusterreply.cpp
+++ b/libnymea-zigbee/zcl/zigbeeclusterreply.cpp
@@ -27,6 +27,18 @@
 
 #include "zigbeeclusterreply.h"
 
+ZigbeeClusterReply::ZigbeeClusterReply(const ZigbeeNetworkRequest &request, ZigbeeClusterLibrary::Frame requestFrame, QObject *parent) :
+    QObject(parent),
+    m_request(request),
+    m_requestFrame(requestFrame)
+{
+    m_timeoutTimer.setInterval(10000);
+    connect(&m_timeoutTimer, &QTimer::timeout, this, [this](){
+        m_error = ErrorTimeout;
+        emit finished();
+    });
+}
+
 ZigbeeClusterReply::Error ZigbeeClusterReply::error() const
 {
     return m_error;
@@ -75,12 +87,4 @@ ZigbeeClusterLibrary::Frame ZigbeeClusterReply::responseFrame() const
 bool ZigbeeClusterReply::isComplete() const
 {
     return m_apsConfirmReceived && m_zclIndicationReceived;
-}
-
-ZigbeeClusterReply::ZigbeeClusterReply(const ZigbeeNetworkRequest &request, ZigbeeClusterLibrary::Frame requestFrame, QObject *parent) :
-    QObject(parent),
-    m_request(request),
-    m_requestFrame(requestFrame)
-{
-
 }

--- a/libnymea-zigbee/zcl/zigbeeclusterreply.h
+++ b/libnymea-zigbee/zcl/zigbeeclusterreply.h
@@ -29,6 +29,7 @@
 #define ZIGBEECLUSTERREPLY_H
 
 #include <QObject>
+#include <QTimer>
 
 #include "zigbeenetworkrequest.h"
 #include "zigbeeclusterlibrary.h"
@@ -72,6 +73,8 @@ private:
     explicit ZigbeeClusterReply(const ZigbeeNetworkRequest &request, ZigbeeClusterLibrary::Frame requestFrame, QObject *parent = nullptr);
 
     Error m_error = ErrorNoError;
+
+    QTimer m_timeoutTimer;
 
     // Request
     quint8 m_transactionSequenceNumber = 0;


### PR DESCRIPTION
This is basically the same as #41 does with ZDO replies but for ZCL replies.

Working with a z-stack dongle and a Gewiss binary input device a lot of
timeouts happen during the device interview. While basic device interview
timeouts are caught by the ZDO timeouts, later interview steps like
cluster attribute reading run into the same issue with this device and
the interview process never finishes.