### PR TITLE
Explicitly stop the ZCL timeout timer

### DIFF
--- a/libnymea-zigbee/zcl/zigbeecluster.cpp
+++ b/libnymea-zigbee/zcl/zigbeecluster.cpp
@@ -208,7 +208,7 @@ ZigbeeClusterReply *ZigbeeCluster::createClusterReply(const ZigbeeNetworkRequest
     connect(zclReply, &ZigbeeClusterReply::finished, this, [this, zclReply](){
         zclReply->deleteLater();
         m_pendingReplies.remove(zclReply->transactionSequenceNumber());
-    }, Qt::QueuedConnection);
+    });
     return zclReply;
 }
 
@@ -412,6 +412,7 @@ void ZigbeeCluster::finishZclReply(ZigbeeClusterReply *zclReply)
 {
     qCDebug(dcZigbeeCluster()) << "ZigbeeClusterReply finished" << zclReply->request() << zclReply->requestFrame() << zclReply->responseFrame();
     // FIXME: Set the status
+    zclReply->m_timeoutTimer.stop();
     emit zclReply->finished();
 }
 

--- a/libnymea-zigbee/zdo/zigbeedeviceobject.cpp
+++ b/libnymea-zigbee/zdo/zigbeedeviceobject.cpp
@@ -661,7 +661,7 @@ ZigbeeDeviceObjectReply *ZigbeeDeviceObject::createZigbeeDeviceObjectReply(const
         if (zdoReply->error() != ZigbeeDeviceObjectReply::ErrorNoError) {
             qCWarning(dcZigbeeDeviceObject()) << "ZDO request error for TSN:" << transactionSequenceNumber;
         }
-    }, Qt::QueuedConnection);
+    });
     m_pendingReplies.insert(transactionSequenceNumber, zdoReply);
     return zdoReply;
 }


### PR DESCRIPTION
Also don't use a QueuedConnection, as it's not guaranteed the
sender will still live on by the time slot is called.