### PR TITLE
Fix permit joining in deconz backend

### DIFF
--- a/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
+++ b/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
@@ -136,12 +136,12 @@ ZigbeeNetworkReply *ZigbeeNetworkDeconz::requestSetPermitJoin(quint16 shortAddre
     // Get the power descriptor
     ZigbeeNetworkRequest request;
     request.setRequestId(generateSequenceNumber());
-    request.setDestinationAddressMode(Zigbee::DestinationAddressModeGroup);
+    request.setDestinationAddressMode(Zigbee::DestinationAddressModeShortAddress);
     request.setDestinationShortAddress(static_cast<quint16>(shortAddress));
     request.setProfileId(Zigbee::ZigbeeProfileDevice); // ZDP
     request.setClusterId(ZigbeeDeviceProfile::MgmtPermitJoinRequest);
     request.setSourceEndpoint(0); // ZDO
-    request.setRadius(10);
+    request.setRadius(30);
 
     // Build ASDU
     QByteArray asdu;

--- a/libnymea-zigbee/backends/nxp/zigbeenetworknxp.cpp
+++ b/libnymea-zigbee/backends/nxp/zigbeenetworknxp.cpp
@@ -225,7 +225,7 @@ ZigbeeNetworkReply *ZigbeeNetworkNxp::requestSetPermitJoin(quint16 shortAddress,
     request.setProfileId(Zigbee::ZigbeeProfileDevice); // ZDP
     request.setClusterId(ZigbeeDeviceProfile::MgmtPermitJoinRequest);
     request.setSourceEndpoint(0); // ZDO
-    request.setRadius(10);
+    request.setRadius(30);
 
     // Build ASDU
     QByteArray asdu;

--- a/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.cpp
+++ b/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.cpp
@@ -672,8 +672,8 @@ ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::addEndpointToGroup(quint8 endp
 ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::requestPermitJoin(quint8 seconds, const quint16 &networkAddress)
 {
     NEW_PAYLOAD;
-    stream << static_cast<quint8>(networkAddress == 0 || networkAddress == 0xFFFC ? 0x0F : 0x02);
-    stream << static_cast<quint16>(networkAddress == 0 ? 0xFFFC : networkAddress);
+    stream << static_cast<quint8>(networkAddress == Zigbee::BroadcastAddressAllRouters ? 0x0F : 0x02);
+    stream << static_cast<quint16>(networkAddress);
     stream << seconds;
     stream << static_cast<quint8>(0x00); // tcsignificance
     ZigbeeInterfaceTiReply *reply = sendCommand(Ti::SubSystemZDO, Ti::ZDOCommandMgmtPermitJoinReq, payload);


### PR DESCRIPTION
The router broadcast address 0xFFFC is not a group addres, but a "regular" address. Setting the destinationAddressMode to GroupAddress caused the message to not be broadcastet and permit joining was only enabled on the coordinator.

This caused mainly the issue that joining a network would not work if the coordinator is out of reach.
In addition to that, there are quite a bit of end devices out there which behave badly in finding new parents and will stick to the node they joined in the first place forever, causing them to have bad signal if further away from the coordinator, even though there would be routers with much better LQI.

Additionally it fixes a permit joining issue in the TI backend which would prevent a call to setPermitJoining(0) to explicitly allow joining only on the coordinator.

The change of radius from 10 to 30 probably isn't needed for 99% of the networks, however, it may still help for that one percent that does indeed have a network depth of > 10. Looking at other implementations out there, 30 seems to be the common sense.