### PR TITLE
Deconz: Fixes for command queuing

### DIFF
--- a/libnymea-zigbee/backends/deconz/interface/zigbeeinterfacedeconzreply.cpp
+++ b/libnymea-zigbee/backends/deconz/interface/zigbeeinterfacedeconzreply.cpp
@@ -84,7 +84,7 @@ ZigbeeInterfaceDeconzReply::ZigbeeInterfaceDeconzReply(Deconz::Command command, 
     m_timer(new QTimer(this)),
     m_command(command)
 {
-    m_timer->setInterval(5000);
+    m_timer->setInterval(10000);
     m_timer->setSingleShot(true);
     connect(m_timer, &QTimer::timeout, this, &ZigbeeInterfaceDeconzReply::onTimeout);
 }

--- a/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
+++ b/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
@@ -76,6 +76,14 @@ ZigbeeNetworkReply *ZigbeeNetworkDeconz::sendRequest(const ZigbeeNetworkRequest 
         return reply;
     }
 
+    if (state() == ZigbeeNetwork::StateStarting) {
+        m_requestQueue.append(reply);
+        connect(reply, &ZigbeeNetworkReply::finished, this, [this, reply](){
+            m_requestQueue.removeAll(reply);
+        });
+        return reply;
+    }
+
     ZigbeeInterfaceDeconzReply *interfaceReply = m_controller->requestSendRequest(request);
     connect(interfaceReply, &ZigbeeInterfaceDeconzReply::finished, reply, [this, reply, interfaceReply](){
         if (interfaceReply->statusCode() != Deconz::StatusCodeSuccess) {
@@ -155,6 +163,25 @@ ZigbeeNetworkReply *ZigbeeNetworkDeconz::requestSetPermitJoin(quint16 shortAddre
 
     qCDebug(dcZigbeeNetwork()) << "Send permit join request" << ZigbeeUtils::convertUint16ToHexString(request.destinationShortAddress()) << duration << "s";
     return sendRequest(request);
+}
+
+void ZigbeeNetworkDeconz::sendPendingRequests()
+{
+    while (!m_requestQueue.isEmpty()) {
+        ZigbeeNetworkReply *reply = m_requestQueue.takeFirst();
+
+        ZigbeeInterfaceDeconzReply *interfaceReply = m_controller->requestSendRequest(reply->request());
+        connect(interfaceReply, &ZigbeeInterfaceDeconzReply::finished, reply, [this, reply, interfaceReply](){
+            if (interfaceReply->statusCode() != Deconz::StatusCodeSuccess) {
+                qCWarning(dcZigbeeController()) << "Could not send request to controller. SQN:" << interfaceReply->sequenceNumber() << interfaceReply->statusCode();
+                finishNetworkReply(reply, ZigbeeNetworkReply::ErrorInterfaceError);
+                return;
+            }
+
+            // The request has been sent successfully to the device, start the timeout timer now
+            startWaitingReply(reply);
+        });
+    }
 }
 
 void ZigbeeNetworkDeconz::setCreateNetworkState(ZigbeeNetworkDeconz::CreateNetworkState state)
@@ -379,6 +406,7 @@ void ZigbeeNetworkDeconz::setCreateNetworkState(ZigbeeNetworkDeconz::CreateNetwo
 
             setState(StateRunning);
             setPermitJoining(0);
+            sendPendingRequests();
             return;
         }
 
@@ -392,6 +420,7 @@ void ZigbeeNetworkDeconz::setCreateNetworkState(ZigbeeNetworkDeconz::CreateNetwo
                 m_initializing = false;
                 setState(StateRunning);
                 setPermitJoining(0);
+                sendPendingRequests();
                 return;
             }
         });
@@ -534,6 +563,7 @@ void ZigbeeNetworkDeconz::runNetworkInitProcess()
 
                                 qCDebug(dcZigbeeNetwork()) << "Set permit join configuration request finished" << reply->statusCode();
                                 setState(StateRunning);
+                                sendPendingRequests();
                             });
 
                         } else if (m_controller->networkState() == Deconz::NetworkStateOffline) {

--- a/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
+++ b/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.cpp
@@ -410,16 +410,16 @@ void ZigbeeNetworkDeconz::setCreateNetworkState(ZigbeeNetworkDeconz::CreateNetwo
             return;
         }
 
+        m_initializing = false;
+        setState(StateRunning);
+        setPermitJoining(0);
+
         ZigbeeNode *coordinatorNode = createNode(m_controller->networkConfiguration().shortAddress, m_controller->networkConfiguration().ieeeAddress, this);
         m_coordinatorNode = coordinatorNode;
 
-        // Network creation done when coordinator node is initialized
         connect(coordinatorNode, &ZigbeeNode::stateChanged, this, [this, coordinatorNode](ZigbeeNode::State state){
             if (state == ZigbeeNode::StateInitialized) {
                 qCDebug(dcZigbeeNetwork()) << "Coordinator initialized successfully." << coordinatorNode;
-                m_initializing = false;
-                setState(StateRunning);
-                setPermitJoining(0);
                 sendPendingRequests();
                 return;
             }

--- a/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.h
+++ b/libnymea-zigbee/backends/deconz/zigbeenetworkdeconz.h
@@ -68,6 +68,7 @@ private:
     QString m_protocolVersion;
     QString m_firmwareVersion;
 
+    QList<ZigbeeNetworkReply*> m_requestQueue;
     QHash<quint8, ZigbeeNetworkReply *> m_pendingReplies;
 
     QTimer *m_pollNetworkStateTimer = nullptr;
@@ -78,6 +79,8 @@ private:
     void runNetworkInitProcess();
 
     ZigbeeNetworkReply *requestSetPermitJoin(quint16 shortAddress = Zigbee::BroadcastAddressAllRouters, quint8 duration = 0xfe);
+
+    void sendPendingRequests();
 
 protected:
     void startNetworkInternally();


### PR DESCRIPTION
Currently, pretty much all zigbee calls done in setupThing() fail because the stack is still starting at startup.

Now that plugins are reworked to also better query the device states on a reconnect, this starts to show in failing calls. This pull request does two things:
a) It queues up calls in zigbeenetworkdeconz while the network is starting so they can be sent once the backend comes up. The TI backend already does this. I'm not sure what happens in the NXP backend, it queues up calls but also passes it down to the controller as long as it is not Offline (i.e. also when it's Starting). Depends on the firmware if those are queued up or failing/being discarded.

b) it also finishes the incomplete implementation of the apsFreeSlotsAvailable controller state in that it marks it as full when we get the Busy status reply and resend the command once we get the controller state notification with freeSlotsAvailable being set to true.
