### PR TITLE
Don't create indices for the databases

### DIFF
--- a/libnymea-zigbee/zigbeenetworkdatabase.cpp
+++ b/libnymea-zigbee/zigbeenetworkdatabase.cpp
@@ -239,7 +239,6 @@ bool ZigbeeNetworkDatabase::initDatabase()
                     "powerDescriptor INTEGER NOT NULL, " // uint16
                     "lqi INTEGER NOT NULL," // uint8
                     "timestamp INTEGER NOT NULL)"); // unix timestamp with the last communication
-        createIndices("ieeeAddressIndex", "nodes", "ieeeAddress");
     }
 
     // Create endpoints table
@@ -252,7 +251,6 @@ bool ZigbeeNetworkDatabase::initDatabase()
                     "deviceId INTEGER NOT NULL, " // uint16
                     "deviceVersion INTEGER, " // uint8
                     "CONSTRAINT fk_ieeeAddress FOREIGN KEY(ieeeAddress) REFERENCES nodes(ieeeAddress) ON DELETE CASCADE)");
-        createIndices("endpointIndex", "endpoints", "ieeeAddress, endpointId");
     }
 
     // Create server cluster table
@@ -262,7 +260,6 @@ bool ZigbeeNetworkDatabase::initDatabase()
                     "endpointId INTEGER NOT NULL, " // reference to endpoint.id
                     "clusterId INTEGER NOT NULL, " // uint16
                     "CONSTRAINT fk_endpoint FOREIGN KEY(endpointId) REFERENCES endpoints(id) ON DELETE CASCADE)");
-        createIndices("serverClusterIndex", "serverClusters", "endpointId, clusterId");
     }
 
     // Create client cluster table
@@ -272,7 +269,6 @@ bool ZigbeeNetworkDatabase::initDatabase()
                     "endpointId INTEGER NOT NULL, " // reference to endpoint.id
                     "clusterId INTEGER NOT NULL, " // uint16
                     "CONSTRAINT fk_endpoint FOREIGN KEY(endpointId) REFERENCES endpoints(id) ON DELETE CASCADE)");
-        createIndices("clientClusterIndex", "clientClusters", "endpointId, clusterId");
     }
 
     // Create cluster attributes table
@@ -284,7 +280,6 @@ bool ZigbeeNetworkDatabase::initDatabase()
                     "dataType INTEGER NOT NULL, " // uint8
                     "data BLOB NOT NULL, " // raw data from attribute
                     "CONSTRAINT fk_cluster FOREIGN KEY(clusterId) REFERENCES serverClusters(id) ON DELETE CASCADE)");
-        createIndices("attributesIndex", "attributes", "clusterId, attributeId");
     }
 
     return true;
@@ -299,12 +294,6 @@ void ZigbeeNetworkDatabase::createTable(const QString &tableName, const QString 
         qCWarning(dcZigbeeNetworkDatabase()) << "Could not create table in database." << query << m_db.lastError().databaseText() << m_db.lastError().driverText();
         return;
     }
-}
-
-void ZigbeeNetworkDatabase::createIndices(const QString &indexName, const QString &tableName, const QString &columns)
-{
-    qCDebug(dcZigbeeNetworkDatabase()) << "Creating table indices" << indexName << tableName << columns;
-    m_db.exec(QString("CREATE UNIQUE INDEX IF NOT EXISTS %1 ON %2(%3);").arg(indexName).arg(tableName).arg(columns));
 }
 
 bool ZigbeeNetworkDatabase::saveNodeEndpoint(ZigbeeNodeEndpoint *endpoint)

--- a/libnymea-zigbee/zigbeenetworkdatabase.h
+++ b/libnymea-zigbee/zigbeenetworkdatabase.h
@@ -62,7 +62,6 @@ private:
 
     bool initDatabase();
     void createTable(const QString &tableName, const QString &schema);
-    void createIndices(const QString &indexName, const QString &tableName, const QString &columns);
 
 public slots:
     bool saveNodeEndpoint(ZigbeeNodeEndpoint *endpoint);


### PR DESCRIPTION
Indices are really helpful on databases that hold many thousands of rows and are searched frequently. On the other hand, indices are harmful on tables which are frequently written to because not only the actual entry needs to be updated but also the index.

So expecially in the particular case of the attributes tables, the index is of more harm than use because we write updates all the time and never read it. Removing the index on the attributes table reduces the disk io footprint of the zigbee db by 30%.

As the other tables are mostly sitting still all the time, the index doesn't really do much harm either in terms of disk io, but it increases the database size, while not providing much benefit, as those entries are also only read once at startup and the tables are reasonably small (a few hundreds).