### PR TITLE
Register the OTA server cluster on the TI backend

### DIFF
--- a/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.cpp
+++ b/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.cpp
@@ -605,7 +605,7 @@ ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::start()
     return sendCommand(Ti::SubSystemZDO, Ti::ZDOCommandStartupFromApp, payload);
 }
 
-ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::registerEndpoint(quint8 endpointId, Zigbee::ZigbeeProfile profile, quint16 deviceId, quint8 deviceVersion)
+ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::registerEndpoint(quint8 endpointId, Zigbee::ZigbeeProfile profile, quint16 deviceId, quint8 deviceVersion, const QList<quint16> &inputClusters, const QList<quint16> &outputClusters)
 {
     if (m_registeredEndpointIds.contains(endpointId)) {
         ZigbeeInterfaceTiReply *reply = new ZigbeeInterfaceTiReply(this);
@@ -621,10 +621,14 @@ ZigbeeInterfaceTiReply *ZigbeeBridgeControllerTi::registerEndpoint(quint8 endpoi
     stream << deviceId;
     stream << deviceVersion;
     stream << static_cast<quint8>(0x00); // latency requirement
-    stream << static_cast<quint8>(0x00); // num input clusters
-//    stream << static_cast<quint16>(0x0000); // input clusters
-    stream << static_cast<quint8>(0x00); // num outout clusters
-//    stream << static_cast<quint16>(0x0000); // output clusters
+    stream << static_cast<quint8>(inputClusters.count());
+    foreach (quint16 inputCluster, inputClusters) {
+        stream << inputCluster;
+    }
+    stream << static_cast<quint8>(outputClusters.count());
+    foreach (quint16 outputCluster, outputClusters) {
+        stream << static_cast<quint16>(outputCluster);
+    }
 
 
     ZigbeeInterfaceTiReply *reply = sendCommand(Ti::SubSystemAF, Ti::AFCommandRegister, payload);

--- a/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.h
+++ b/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.h
@@ -87,7 +87,7 @@ public:
     ZigbeeInterfaceTiReply *setLed(bool on);
 
     ZigbeeInterfaceTiReply *requestPermitJoin(quint8 seconds, const quint16 &networkAddress);
-    ZigbeeInterfaceTiReply *registerEndpoint(quint8 endpointId, Zigbee::ZigbeeProfile profile, quint16 deviceId, quint8 deviceVersion);
+    ZigbeeInterfaceTiReply *registerEndpoint(quint8 endpointId, Zigbee::ZigbeeProfile profile, quint16 deviceId, quint8 deviceVersion, const QList<quint16> &inputClusters = QList<quint16>(), const QList<quint16> &outputClusters = QList<quint16>());
     ZigbeeInterfaceTiReply *addEndpointToGroup(quint8 endpointId, quint16 groupId);
 
     // Send APS request data


### PR DESCRIPTION
This is required by some devices (at least Tradfri) in order to query us for images.