### PR TITLE
Expose raw dataIndications and allow sending raw commands on ZigbeeCluster

### DIFF
--- a/libnymea-zigbee/zcl/zigbeecluster.cpp
+++ b/libnymea-zigbee/zcl/zigbeecluster.cpp
@@ -212,7 +212,7 @@ ZigbeeClusterReply *ZigbeeCluster::createClusterReply(const ZigbeeNetworkRequest
     return zclReply;
 }
 
-ZigbeeClusterReply *ZigbeeCluster::executeClusterCommand(quint8 command, const QByteArray &payload, ZigbeeClusterLibrary::Direction direction)
+ZigbeeClusterReply *ZigbeeCluster::executeClusterCommand(quint8 command, const QByteArray &payload, ZigbeeClusterLibrary::Direction direction, bool disableDefaultResponse)
 {
     ZigbeeNetworkRequest request = createGeneralRequest();
 
@@ -221,7 +221,7 @@ ZigbeeClusterReply *ZigbeeCluster::executeClusterCommand(quint8 command, const Q
     frameControl.frameType = ZigbeeClusterLibrary::FrameTypeClusterSpecific;
     frameControl.manufacturerSpecific = false;
     frameControl.direction = direction;
-    frameControl.disableDefaultResponse = false;
+    frameControl.disableDefaultResponse = disableDefaultResponse;
 
     // Build ZCL header
     ZigbeeClusterLibrary::Header header;
@@ -419,7 +419,8 @@ void ZigbeeCluster::finishZclReply(ZigbeeClusterReply *zclReply)
 void ZigbeeCluster::processDataIndication(ZigbeeClusterLibrary::Frame frame)
 {
     // Warn about the unhandled cluster indication, you can override this method in cluster implementations
-    qCWarning(dcZigbeeCluster()) << "Unhandled ZCL indication in" << m_node << m_endpoint << this << frame;
+    qCDebug(dcZigbeeCluster()) << "Unhandled ZCL indication in" << m_node << m_endpoint << this << frame;
+    emit dataIndication(frame);
 }
 
 quint8 ZigbeeCluster::newTransactionSequenceNumber()

--- a/libnymea-zigbee/zcl/zigbeecluster.h
+++ b/libnymea-zigbee/zcl/zigbeecluster.h
@@ -94,6 +94,22 @@ public:
     ZigbeeClusterReply *writeAttributes(QList<ZigbeeClusterLibrary::WriteAttributeRecord> writeAttributeRecords, quint16 manufacturerCode = 0x0000);
     ZigbeeClusterReply *configureReporting(QList<ZigbeeClusterLibrary::AttributeReportingConfiguration> reportingConfigurations, quint16 manufacturerCode = 0x0000);
 
+    // Helper methods for sending cluster specific commands
+    ZigbeeNetworkRequest createGeneralRequest();
+
+    // Global commands
+    ZigbeeClusterReply *executeGlobalCommand(quint8 command, const QByteArray &payload = QByteArray(), quint16 manufacturerCode = 0x0000, quint8 transactionSequenceNumber = newTransactionSequenceNumber());
+
+    // Cluster specific
+    ZigbeeClusterReply *createClusterReply(const ZigbeeNetworkRequest &request, ZigbeeClusterLibrary::Frame frame);
+    ZigbeeClusterReply *executeClusterCommand(quint8 command, const QByteArray &payload = QByteArray(), ZigbeeClusterLibrary::Direction direction = ZigbeeClusterLibrary::DirectionClientToServer, bool disableDefaultResponse = false);
+
+    ZigbeeClusterReply *sendClusterServerResponse(quint8 command, quint8 transactionSequenceNumber, const QByteArray &payload = QByteArray());
+    ZigbeeClusterReply *sendDefaultResponse(quint8 transactionSequenceNumber, quint8 command, quint8 status);
+
+    bool verifyNetworkError(ZigbeeClusterReply *zclReply, ZigbeeNetworkReply *networkReply);
+    void finishZclReply(ZigbeeClusterReply *zclReply);
+
 protected:
     ZigbeeNetwork *m_network = nullptr;
     ZigbeeNode *m_node = nullptr;
@@ -103,22 +119,7 @@ protected:
     Direction m_direction = Server;
     QHash<quint16, ZigbeeClusterAttribute> m_attributes;
 
-    // Helper methods for sending cluster specific commands
-    ZigbeeNetworkRequest createGeneralRequest();
     QHash<quint8, ZigbeeClusterReply *> m_pendingReplies;
-
-    // Global commands
-    ZigbeeClusterReply *executeGlobalCommand(quint8 command, const QByteArray &payload = QByteArray(), quint16 manufacturerCode = 0x0000, quint8 transactionSequenceNumber = newTransactionSequenceNumber());
-
-    // Cluster specific
-    ZigbeeClusterReply *createClusterReply(const ZigbeeNetworkRequest &request, ZigbeeClusterLibrary::Frame frame);
-    ZigbeeClusterReply *executeClusterCommand(quint8 command, const QByteArray &payload = QByteArray(), ZigbeeClusterLibrary::Direction direction = ZigbeeClusterLibrary::DirectionClientToServer);
-
-    ZigbeeClusterReply *sendClusterServerResponse(quint8 command, quint8 transactionSequenceNumber, const QByteArray &payload = QByteArray());
-    ZigbeeClusterReply *sendDefaultResponse(quint8 transactionSequenceNumber, quint8 command, quint8 status);
-
-    bool verifyNetworkError(ZigbeeClusterReply *zclReply, ZigbeeNetworkReply *networkReply);
-    void finishZclReply(ZigbeeClusterReply *zclReply);
 
     virtual void processDataIndication(ZigbeeClusterLibrary::Frame frame);
 
@@ -128,6 +129,7 @@ protected:
 
 signals:
     void attributeChanged(const ZigbeeClusterAttribute &attribute);
+    void dataIndication(const ZigbeeClusterLibrary::Frame &frame);
 
 public slots:
     void processApsDataIndication(const QByteArray &asdu, const ZigbeeClusterLibrary::Frame &frame);


### PR DESCRIPTION
This is required to allow interacting with devices that use custom clusters and go beyond attribute reporting.