### PR TITLE
Fix an occational crash in the deconz backend

### DIFF
--- a/libnymea-zigbee/backends/deconz/zigbeebridgecontrollerdeconz.cpp
+++ b/libnymea-zigbee/backends/deconz/zigbeebridgecontrollerdeconz.cpp
@@ -298,6 +298,9 @@ ZigbeeInterfaceDeconzReply *ZigbeeBridgeControllerDeconz::createReply(Deconz::Co
         m_replyQueue.enqueue(reply);
         qCDebug(dcZigbeeController()) << "Enqueue request:" << reply->requestName();
     }
+    connect(reply, &ZigbeeInterfaceDeconzReply::timeout, this, [=](){
+        m_replyQueue.removeAll(reply);
+    });
 
     QMetaObject::invokeMethod(this, "sendNextRequest", Qt::QueuedConnection);
     return reply;


### PR DESCRIPTION
May happen if the queue runs full and controller requests time out