### PR TITLE
TI: fix reconncting the controller at runtime 

### DIFF
--- a/libnymea-zigbee/backends/ti/interface/zigbeeinterfacetireply.cpp
+++ b/libnymea-zigbee/backends/ti/interface/zigbeeinterfacetireply.cpp
@@ -52,7 +52,7 @@ Ti::StatusCode ZigbeeInterfaceTiReply::statusCode() const
     return m_statusCode;
 }
 
-bool ZigbeeInterfaceTiReply::timendOut() const
+bool ZigbeeInterfaceTiReply::timedOut() const
 {
     return m_timeout;
 }

--- a/libnymea-zigbee/backends/ti/interface/zigbeeinterfacetireply.h
+++ b/libnymea-zigbee/backends/ti/interface/zigbeeinterfacetireply.h
@@ -54,7 +54,7 @@ public:
     // Response content
     Ti::StatusCode statusCode() const;
 
-    bool timendOut() const;
+    bool timedOut() const;
     bool aborted() const;
     void abort();
 

--- a/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.h
+++ b/libnymea-zigbee/backends/ti/zigbeebridgecontrollerti.h
@@ -144,6 +144,7 @@ private:
     QTimer m_permitJoinTimer;
 
     QList<int> m_registeredEndpointIds;
+    int m_timeouts = 0;
 
     void finishRequest(Ti::StatusCode statusCode = Ti::StatusCodeSuccess);
 };

--- a/libnymea-zigbee/zcl/zigbeecluster.cpp
+++ b/libnymea-zigbee/zcl/zigbeecluster.cpp
@@ -206,6 +206,7 @@ ZigbeeClusterReply *ZigbeeCluster::createClusterReply(const ZigbeeNetworkRequest
     zclReply->m_transactionSequenceNumber = frame.header.transactionSequenceNumber;
     m_pendingReplies.insert(zclReply->transactionSequenceNumber(), zclReply);
     connect(zclReply, &ZigbeeClusterReply::finished, this, [this, zclReply](){
+        qCDebug(dcZigbeeCluster()) << "ZCL request to" << zclReply->request().destinationShortAddress() << "finished with status:" << zclReply->error();
         zclReply->deleteLater();
         m_pendingReplies.remove(zclReply->transactionSequenceNumber());
     });
@@ -367,6 +368,7 @@ bool ZigbeeCluster::verifyNetworkError(ZigbeeClusterReply *zclReply, ZigbeeNetwo
     case ZigbeeNetworkReply::ErrorNoError:
         // The request has been transported successfully to he destination, now
         // wait for the expected indication or check if we already recieved it
+        qCDebug(dcZigbeeCluster()) << "ZCL request sent. Waiting for response data indication...";
         zclReply->m_apsConfirmReceived = true;
         if (!zclReply->m_zclIndicationReceived) {
             zclReply->m_timeoutTimer.start();


### PR DESCRIPTION
Fixes reconnecting the ZigBee controller after a reset during runtime

Resets may occur by unplugging the stick or calling a softReset() from
the software side.

Additionally resets the stick when 5 subsequent timeouts happen
as there are firmwares of the CC2652 available which tend to
crash occationally.
