### PR TITLE
Align command signal names in clusters

### DIFF
--- a/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.cpp
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.cpp
@@ -134,7 +134,7 @@ void ZigbeeClusterLevelControl::processDataIndication(ZigbeeClusterLibrary::Fram
         if (frame.header.frameControl.direction == ZigbeeClusterLibrary::DirectionClientToServer) {
             // Read the payload which is
             Command command = static_cast<Command>(frame.header.command);
-            emit commandSent(command, frame.payload, frame.header.transactionSequenceNumber);
+            emit commandReceived(command, frame.payload, frame.header.transactionSequenceNumber);
 
             bool withOnOff = false;
             switch (command) {
@@ -147,7 +147,7 @@ void ZigbeeClusterLevelControl::processDataIndication(ZigbeeClusterLibrary::Fram
                 payloadStream >> level >> transitionTime;
                 withOnOff = command == CommandMoveToLevelWithOnOff;
                 qCDebug(dcZigbeeCluster()).noquote().nospace() << "Command received from " << m_node << " " << m_endpoint << " " << this << " " << command << " withOnOff: " << withOnOff << " level: 0x" << QString::number(level, 16) << " transitionTime: 0x" << QString::number(transitionTime, 16);
-                emit commandMoveToLevelSent(withOnOff, level, transitionTime, frame.header.transactionSequenceNumber);
+                emit commandMoveToLevelReceived(withOnOff, level, transitionTime, frame.header.transactionSequenceNumber);
                 break;
             }
             case CommandStepWithOnOff:
@@ -159,7 +159,7 @@ void ZigbeeClusterLevelControl::processDataIndication(ZigbeeClusterLibrary::Fram
                 payloadStream >> stepModeValue >> stepSize >> transitionTime;
                 withOnOff = command == CommandMoveToLevelWithOnOff;
                 qCDebug(dcZigbeeCluster()).noquote().nospace() << "Command received from " << m_node << " " << m_endpoint << " " << this << " " << command << " withOnOff: " << withOnOff << " stepModeValue: 0x" << QString::number(stepModeValue, 16) << " stepSize: 0x" << QString::number(stepSize, 16) << " transitionTime: 0x" << QString::number(transitionTime, 16);
-                emit commandStepSent(withOnOff, static_cast<StepMode>(stepModeValue), stepSize, transitionTime, frame.header.transactionSequenceNumber);
+                emit commandStepReceived(withOnOff, static_cast<StepMode>(stepModeValue), stepSize, transitionTime, frame.header.transactionSequenceNumber);
                 break;
             }
             case CommandMoveWithOnOff:
@@ -171,13 +171,13 @@ void ZigbeeClusterLevelControl::processDataIndication(ZigbeeClusterLibrary::Fram
                 payloadStream >> moveModeValue >> rate;
                 withOnOff = command == CommandMoveToLevelWithOnOff;
                 qCDebug(dcZigbeeCluster()).noquote().nospace() << "Command received from " << m_node << " " << m_endpoint << " " << this << " " << command << " withOnOff:" << withOnOff <<  " moveModeValue: 0x" << QString::number(moveModeValue, 16) << " rate: 0x" << QString::number(rate, 16);
-                emit commandMoveSent(withOnOff, static_cast<MoveMode>(moveModeValue), rate, frame.header.transactionSequenceNumber);
+                emit commandMoveReceived(withOnOff, static_cast<MoveMode>(moveModeValue), rate, frame.header.transactionSequenceNumber);
                 break;
             }
             case CommandStopWithOnOff:
             case CommandStop:
                 withOnOff = command == CommandMoveToLevelWithOnOff;
-                emit commandStopSent(withOnOff, frame.header.transactionSequenceNumber);
+                emit commandStopReceived(withOnOff, frame.header.transactionSequenceNumber);
                 break;
             default:
                 qCDebug(dcZigbeeCluster()).noquote().nospace() << "Command received from " << m_node << " " << m_endpoint << " " << this << " " << command << " payload: 0x" << ZigbeeUtils::convertByteArrayToHexString(frame.payload);

--- a/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterlevelcontrol.h
@@ -106,11 +106,11 @@ protected:
 
 signals:
     void currentLevelChanged(quint8 level);
-    void commandSent(ZigbeeClusterLevelControl::Command command, const QByteArray &parameter, quint8 transactionSequenceNumber);
-    void commandMoveToLevelSent(bool withOnOff, quint8 level, quint16 transitionTime, quint8 transactionSequenceNumber);
-    void commandMoveSent(bool withOnOff, MoveMode moveMode, quint8 rate, quint8 transactionSeqenceNumber);
-    void commandStepSent(bool withOnOff, StepMode stepMode, quint8 stepSize, quint16 transitionTime, quint8 transactionSequenceNumber);
-    void commandStopSent(bool withOnOff, quint8 transactionSequenceNumber);
+    void commandReceived(ZigbeeClusterLevelControl::Command command, const QByteArray &parameter, quint8 transactionSequenceNumber);
+    void commandMoveToLevelReceived(bool withOnOff, quint8 level, quint16 transitionTime, quint8 transactionSequenceNumber);
+    void commandMoveReceived(bool withOnOff, MoveMode moveMode, quint8 rate, quint8 transactionSeqenceNumber);
+    void commandStepReceived(bool withOnOff, StepMode stepMode, quint8 stepSize, quint16 transitionTime, quint8 transactionSequenceNumber);
+    void commandStopReceived(bool withOnOff, quint8 transactionSequenceNumber);
 
 };
 

--- a/libnymea-zigbee/zcl/general/zigbeeclusteronoff.cpp
+++ b/libnymea-zigbee/zcl/general/zigbeeclusteronoff.cpp
@@ -110,7 +110,7 @@ void ZigbeeClusterOnOff::processDataIndication(ZigbeeClusterLibrary::Frame frame
         if (frame.header.frameControl.direction == ZigbeeClusterLibrary::DirectionClientToServer) {
             // Read the payload which is
             Command command = static_cast<Command>(frame.header.command);
-            emit commandSent(command, frame.payload, frame.header.transactionSequenceNumber);
+            emit commandReceived(command, frame.payload, frame.header.transactionSequenceNumber);
             switch (command) {
             case CommandOffWithEffect: {
                 QByteArray payload = frame.payload;
@@ -119,7 +119,7 @@ void ZigbeeClusterOnOff::processDataIndication(ZigbeeClusterLibrary::Frame frame
                 quint8 effectValue = 0; quint16 effectVariant;
                 payloadStream >> effectValue >> effectVariant;
                 qCDebug(dcZigbeeCluster()) << "Command received from" << m_node << m_endpoint << this << command << "effect:" << effectValue << "effectVariant:" << effectVariant;
-                emit commandOffWithEffectSent(static_cast<Effect>(effectValue), effectVariant, frame.header.transactionSequenceNumber);
+                emit commandOffWithEffectReceived(static_cast<Effect>(effectValue), effectVariant, frame.header.transactionSequenceNumber);
                 break;
             }
             case CommandOnWithTimedOff: {
@@ -129,7 +129,7 @@ void ZigbeeClusterOnOff::processDataIndication(ZigbeeClusterLibrary::Frame frame
                 quint8 acceptOnlyWhenOnInt = 0; quint16 onTime; quint16 offTime;
                 payloadStream >> acceptOnlyWhenOnInt >> onTime >> offTime;
                 qCDebug(dcZigbeeCluster()) << "Command received from" << m_node << m_endpoint << this << command << "accentOnlyWhenOnInt:" << acceptOnlyWhenOnInt << "onTime:" << onTime << "offTime:" << offTime;
-                emit commandOnWithTimedOffSent(static_cast<bool>(acceptOnlyWhenOnInt), onTime, offTime, frame.header.transactionSequenceNumber);
+                emit commandOnWithTimedOffReceived(static_cast<bool>(acceptOnlyWhenOnInt), onTime, offTime, frame.header.transactionSequenceNumber);
                 break;
             }
             default:

--- a/libnymea-zigbee/zcl/general/zigbeeclusteronoff.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusteronoff.h
@@ -94,12 +94,12 @@ signals:
     void powerChanged(bool power);
 
     // Client cluster signals
-    void commandSent(ZigbeeClusterOnOff::Command command, const QByteArray &parameters, quint8 transactionSequenceNumber);
+    void commandReceived(ZigbeeClusterOnOff::Command command, const QByteArray &parameters, quint8 transactionSequenceNumber);
     // On and off time is in 1/10 seconds
-    void commandOnWithTimedOffSent(bool acceptOnlyWhenOn, quint16 onTime, quint16 offTime, quint8 transactionSequenceNumber);
+    void commandOnWithTimedOffReceived(bool acceptOnlyWhenOn, quint16 onTime, quint16 offTime, quint8 transactionSequenceNumber);
 
     // On and off time is in 1/10 seconds
-    void commandOffWithEffectSent(ZigbeeClusterOnOff::Effect effect, quint8 effectVariant, quint8 transactionSequenceNumber);
+    void commandOffWithEffectReceived(ZigbeeClusterOnOff::Effect effect, quint8 effectVariant, quint8 transactionSequenceNumber);
 };
 
 #endif // ZIGBEECLUSTERONOFF_H

--- a/libnymea-zigbee/zcl/general/zigbeeclusterscenes.cpp
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterscenes.cpp
@@ -49,7 +49,7 @@ void ZigbeeClusterScenes::processDataIndication(ZigbeeClusterLibrary::Frame fram
         quint16 groupId = 0; quint8 sceneId;
         payloadStream >> groupId >> sceneId;
         qCDebug(dcZigbeeCluster()).noquote() << "Received" << command << "for group" << "0x" + QString::number(groupId, 16) << "and scene" << sceneId << "from" << m_node << m_endpoint << this;
-        emit commandSent(command, groupId, sceneId, frame.header.transactionSequenceNumber);
+        emit commandReceived(command, groupId, sceneId, frame.header.transactionSequenceNumber);
         break;
     }
     case Server:

--- a/libnymea-zigbee/zcl/general/zigbeeclusterscenes.h
+++ b/libnymea-zigbee/zcl/general/zigbeeclusterscenes.h
@@ -63,7 +63,7 @@ public:
     explicit ZigbeeClusterScenes(ZigbeeNetwork *network, ZigbeeNode *node, ZigbeeNodeEndpoint *endpoint, Direction direction, QObject *parent = nullptr);
 
 signals:
-    void commandSent(ZigbeeClusterScenes::Command command, quint16 groupId, quint8 sceneId, quint8 transactionSequenceNumber);
+    void commandReceived(ZigbeeClusterScenes::Command command, quint16 groupId, quint8 sceneId, quint8 transactionSequenceNumber);
 
 protected:
     void processDataIndication(ZigbeeClusterLibrary::Frame frame) override;

--- a/libnymea-zigbee/zcl/lighting/zigbeeclustercolorcontrol.cpp
+++ b/libnymea-zigbee/zcl/lighting/zigbeeclustercolorcontrol.cpp
@@ -223,6 +223,22 @@ ZigbeeClusterColorControl::ColorCapabilities ZigbeeClusterColorControl::colorCap
     return m_colorCapabilities;
 }
 
+void ZigbeeClusterColorControl::processDataIndication(ZigbeeClusterLibrary::Frame frame)
+{
+    switch (m_direction) {
+    case Client:
+        if (frame.header.frameControl.direction == ZigbeeClusterLibrary::DirectionClientToServer) {
+            Command command = static_cast<Command>(frame.header.command);
+            emit commandReceived(command, frame.payload, frame.header.transactionSequenceNumber);
+        }
+        break;
+    case Server:
+        qCWarning(dcZigbeeCluster()) << "Unhandled ZCL indication in" << m_node << m_endpoint << this << frame;
+        break;
+    }
+
+}
+
 void ZigbeeClusterColorControl::setAttribute(const ZigbeeClusterAttribute &attribute)
 {
     qCDebug(dcZigbeeCluster()) << "Attribute changed" << m_node << m_endpoint << this << static_cast<Attribute>(attribute.id()) << attribute.dataType();

--- a/libnymea-zigbee/zcl/lighting/zigbeeclustercolorcontrol.h
+++ b/libnymea-zigbee/zcl/lighting/zigbeeclustercolorcontrol.h
@@ -238,6 +238,11 @@ signals:
     void colorTemperatureMiredsChanged(quint16 colorTemperatureMireds);
     void colorCapabilitiesChanged(ColorCapabilities colorCapabilities);
 
+    void commandReceived(ZigbeeClusterColorControl::Command command, const QByteArray &payload, quint8 transactionSequenceNumber);
+
+protected:
+    void processDataIndication(ZigbeeClusterLibrary::Frame frame) override;
+
 private:
     quint16 m_colorTemperatureMireds = 0;
     ColorCapabilities m_colorCapabilities = ColorCapabilities();


### PR DESCRIPTION
Originally the intention was to add the commandReceived() signal to the ColorControl cluster but noticing differences in various clusters wrt commandSent() and commandReceived() namings of those signals.

Decided to commandReceived() as it feels more natural to use and also the Zigbee cluster spec uses that wording.