### PR TITLE
Fix sleepy device being marked as reachable after a long time of being unreachable

### DIFF
--- a/libnymea-zigbee/zigbeenetwork.cpp
+++ b/libnymea-zigbee/zigbeenetwork.cpp
@@ -978,7 +978,7 @@ void ZigbeeNetwork::evaluateNodeReachableStates()
         } else {
             // Note: sleeping devices should send some message within 6 hours,
             // otherwise the device might not be reachable any more
-            int msSinceLastSeen = node->lastSeen().msecsTo(QDateTime::currentDateTimeUtc());
+            qint64 msSinceLastSeen = node->lastSeen().msecsTo(QDateTime::currentDateTimeUtc());
             qCDebug(dcZigbeeNetwork()) << node << "has been seen the last time" << QTime::fromMSecsSinceStartOfDay(msSinceLastSeen).toString() << "ago.";
             // 6 Hours = 6 * 60 * 60 * 1000 = 21600000 ms
             if (msSinceLastSeen < 21600000) {


### PR DESCRIPTION
Integer overflow